### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends texlive-full
+    && apt-get -y install --no-install-recommends texlive-full librsvg2-bin
     
 RUN chsh -s /usr/bin/zsh vscode


### PR DESCRIPTION
Including librsvg2-bin, which provides rsvg-convert.
Using rsvg-convert with latexmk allows the automatic, conversion of .svg images to .pdf, saving some headaches on that end.